### PR TITLE
 add pre-supported print settings for SL1 and SL1S

### DIFF
--- a/PrusaResearchSLA/1.0.4.ini
+++ b/PrusaResearchSLA/1.0.4.ini
@@ -70,12 +70,19 @@ support_pillar_diameter = 1
 output_filename_format = [input_filename_base].sl1s
 compatible_printers_condition = printer_model=="SL1S"
 
+[sla_print:*pre-supported*]
+pad_enable = 0
+supports_enable = 0
+
 # SL1 #
 
 [sla_print:0.025 UltraDetail]
 inherits = *common*
 layer_height = 0.025
 support_head_width = 2
+
+[sla_print:0.025 UltraDetail pre-supported]
+inherits = 0.025 UltraDetail; *pre-supported*
 
 ; [sla_print:0.035 Detail]
 ; inherits = *common*
@@ -85,12 +92,18 @@ support_head_width = 2
 inherits = *common*
 layer_height = 0.05
 
+[sla_print:0.05 Normal pre-supported]
+inherits = 0.05 Normal; *pre-supported*
+
 [sla_print:0.1 Fast]
 inherits = *common*
 layer_height = 0.1
 support_head_front_diameter = 0.5
 support_head_penetration = 0.5
 support_pillar_diameter = 1.3
+
+[sla_print:0.1 Fast pre-supported]
+inherits = 0.1 Fast; *pre-supported*
 
 # SL1S #
 
@@ -99,15 +112,24 @@ inherits = *SL1S*
 layer_height = 0.025
 support_head_width = 3
 
+[sla_print:0.025 UltraDetail pre-supported @SL1S]
+inherits = 0.025 UltraDetail @SL1S; *pre-supported*
+
 [sla_print:0.05 Normal @SL1S]
 inherits = *SL1S*
 layer_height = 0.05
+
+[sla_print:0.05 Normal pre-supported @SL1S]
+inherits = 0.05 Normal @SL1S; *pre-supported*
 
 [sla_print:0.1 Fast @SL1S]
 inherits = *SL1S*
 layer_height = 0.1
 support_head_front_diameter = 0.6
 support_head_penetration = 0.6
+
+[sla_print:0.1 Fast pre-supported @SL1S]
+inherits = 0.1 Fast @SL1S; *pre-supported*
 
 ########### Materials
 

--- a/PrusaResearchSLA/1.0.4.ini
+++ b/PrusaResearchSLA/1.0.4.ini
@@ -1,0 +1,4170 @@
+# Print profiles for Prusa Research printers.
+
+[vendor]
+repo_id = prusa-sla
+# Vendor name will be shown by the Config Wizard.
+name = Prusa Research SLA
+# Configuration version of this file. Config file will only be installed, if the config_version differs.
+# This means, the server may force the PrusaSlicer configuration to be downgraded.
+config_version = 1.0.4
+
+config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/PrusaResearchSLA/
+# changelog_url = https://files.prusa3d.com/?latest=slicer-profiles&lng=%1%
+
+[printer_model:SL1S]
+name = Original Prusa SL1S SPEED
+variants = default
+technology = SLA
+family = SL1
+bed_model = sl1s_bed.stl
+bed_texture = sl1s.svg
+default_materials = Prusament Resin Tough Prusa Orange @0.05 SL1S
+
+[printer_model:SL1]
+name = Original Prusa SL1
+variants = default
+technology = SLA
+family = SL1
+bed_model = sl1_bed.stl
+bed_texture = sl1.svg
+default_materials = Prusament Resin Tough Prusa Orange @0.05
+
+# All presets starting with asterisk, for example *common*, are intermediate and they will
+# not make it into the user interface.
+
+# Common print presets
+
+[sla_print:*common*]
+compatible_printers_condition = printer_model=="SL1"
+layer_height = 0.05
+output_filename_format = [input_filename_base].sl1
+pad_edge_radius = 0.5
+pad_enable = 1
+pad_max_merge_distance = 50
+pad_wall_height = 0
+pad_wall_thickness = 1
+pad_wall_slope = 45
+slice_closing_radius = 0.005
+support_base_diameter = 3
+support_base_height = 1
+support_critical_angle = 45
+support_density_at_45 = 250
+support_density_at_horizontal = 500
+support_head_front_diameter = 0.4
+support_head_penetration = 0.4
+support_head_width = 3
+support_max_bridge_length = 10
+support_minimal_z = 0
+support_object_elevation = 5
+support_pillar_diameter = 1
+support_pillar_connection_mode = zigzag
+support_pillar_widening_factor = 0
+supports_enable = 1
+support_small_pillar_diameter_percent = 60%
+
+[sla_print:*SL1S*]
+inherits = *common*
+support_head_front_diameter = 0.5
+support_head_penetration = 0.5
+support_pillar_diameter = 1
+output_filename_format = [input_filename_base].sl1s
+compatible_printers_condition = printer_model=="SL1S"
+
+# SL1 #
+
+[sla_print:0.025 UltraDetail]
+inherits = *common*
+layer_height = 0.025
+support_head_width = 2
+
+; [sla_print:0.035 Detail]
+; inherits = *common*
+; layer_height = 0.035
+
+[sla_print:0.05 Normal]
+inherits = *common*
+layer_height = 0.05
+
+[sla_print:0.1 Fast]
+inherits = *common*
+layer_height = 0.1
+support_head_front_diameter = 0.5
+support_head_penetration = 0.5
+support_pillar_diameter = 1.3
+
+# SL1S #
+
+[sla_print:0.025 UltraDetail @SL1S]
+inherits = *SL1S*
+layer_height = 0.025
+support_head_width = 3
+
+[sla_print:0.05 Normal @SL1S]
+inherits = *SL1S*
+layer_height = 0.05
+
+[sla_print:0.1 Fast @SL1S]
+inherits = *SL1S*
+layer_height = 0.1
+support_head_front_diameter = 0.6
+support_head_penetration = 0.6
+
+########### Materials
+
+[sla_material:*common*]
+compatible_printers_condition = printer_model=="SL1"
+compatible_prints_condition = layer_height == 0.05
+exposure_time = 12
+initial_exposure_time = 45
+initial_layer_height = 0.05
+material_correction = 1,1,1
+material_notes = 
+material_print_speed = fast
+
+# SL1
+
+[sla_material:*common 0.025*]
+inherits = *common*
+compatible_prints_condition = layer_height == 0.025
+exposure_time = 10
+initial_exposure_time = 35
+initial_layer_height = 0.025
+
+[sla_material:*common 0.035*]
+inherits = *common*
+compatible_prints_condition = layer_height == 0.035
+exposure_time = 13
+initial_exposure_time = 40
+initial_layer_height = 0.035
+
+[sla_material:*common 0.05*]
+inherits = *common*
+
+[sla_material:*common 0.1*]
+inherits = *common*
+compatible_prints_condition = layer_height == 0.1
+exposure_time = 20
+initial_exposure_time = 45
+initial_layer_height = 0.1
+
+[sla_material:*sl1_fast*]
+area_fill = 35
+delay_before_exposure = 0,1
+delay_after_exposure = 0,0
+tower_hop_height = 0,0
+tower_speed = layer22,layer22
+use_tilt = 1,1
+tilt_down_initial_speed = layer400,layer400
+tilt_down_offset_steps = 0,0
+tilt_down_offset_delay = 0,0
+tilt_down_finish_speed = layer1750,layer1500
+tilt_down_cycles = 1,1
+tilt_down_delay = 0,0
+tilt_up_initial_speed = move5120,move5120
+tilt_up_offset_steps = 400,400
+tilt_up_offset_delay = 0,0
+tilt_up_finish_speed = layer400,layer400
+tilt_up_cycles = 1,1
+tilt_up_delay = 0,0
+# For legacy slicer versions
+material_print_speed = fast
+
+# SL1S
+
+[sla_material:*0.025_sl1s*]
+inherits = *common*
+compatible_prints_condition = layer_height == 0.025
+compatible_printers_condition = printer_model=="SL1S"
+exposure_time = 1.3
+initial_exposure_time = 25
+initial_layer_height = 0.025
+
+[sla_material:*0.05_sl1s*]
+inherits = *common*
+compatible_printers_condition = printer_model=="SL1S"
+exposure_time = 1.7
+initial_exposure_time = 25
+
+[sla_material:*0.1_sl1s*]
+inherits = *common*
+compatible_prints_condition = layer_height == 0.1
+compatible_printers_condition = printer_model=="SL1S"
+exposure_time = 2.6
+initial_exposure_time = 25
+initial_layer_height = 0.1
+
+[sla_material:*sl1s_slow*]
+area_fill = 35
+delay_before_exposure = 3,3
+delay_after_exposure = 0,0
+tower_hop_height = 0,0
+tower_speed = layer22,layer22
+use_tilt = 1,1
+tilt_down_initial_speed = layer1750,layer1750
+tilt_down_offset_steps = 0,0
+tilt_down_offset_delay = 0,0
+tilt_down_finish_speed = layer1750,layer1750
+tilt_down_cycles = 1,1
+tilt_down_delay = 0,0
+tilt_up_initial_speed = move8000,move8000
+tilt_up_offset_steps = 1200,1200
+tilt_up_offset_delay = 0,0
+tilt_up_finish_speed = layer1750,layer1750
+tilt_up_cycles = 1,1
+tilt_up_delay = 0,0
+# For legacy slicer versions
+material_print_speed = slow
+
+[sla_material:*sl1s_fast*]
+area_fill = 35
+delay_before_exposure = 0,1
+delay_after_exposure = 0,0
+tower_hop_height = 0,0
+tower_speed = layer22,layer22
+use_tilt = 1,1
+tilt_down_initial_speed = layer1750,layer1750
+tilt_down_offset_steps = 0,0
+tilt_down_offset_delay = 0,0
+tilt_down_finish_speed = move8000,layer1750
+tilt_down_cycles = 1,1
+tilt_down_delay = 0,0
+tilt_up_initial_speed = move8000,move8000
+tilt_up_offset_steps = 600,600
+tilt_up_offset_delay = 0,0
+tilt_up_finish_speed = layer1750,layer1750
+tilt_up_cycles = 1,1
+tilt_up_delay = 0,0
+# For legacy slicer versions
+material_print_speed = slow
+
+[sla_material:*sl1s_hv*]
+area_fill = 35
+delay_before_exposure = 3.5,3.5
+delay_after_exposure = 0,0
+tower_hop_height = 5,5
+tower_speed = layer2,layer2
+use_tilt = 1,1
+tilt_down_initial_speed = layer800,layer800
+tilt_down_offset_steps = 2200,2200
+tilt_down_offset_delay = 0,0
+tilt_down_finish_speed = layer1750,layer1750
+tilt_down_cycles = 1,1
+tilt_down_delay = 0,0
+tilt_up_initial_speed = layer1750,layer1750
+tilt_up_offset_steps = 2200,2200
+tilt_up_offset_delay = 0,0
+tilt_up_finish_speed = layer800,layer800
+tilt_up_cycles = 1,1
+tilt_up_delay = 0,0
+# For legacy slicer versions
+material_print_speed = slow
+
+[sla_material:*legacy_fast*]
+# For legacy slicer versions
+material_print_speed = fast
+
+########### Materials 0.025
+
+[sla_material:3DM-ABS @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 12
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = 3DM
+material_colour = #FF8040
+
+[sla_material:3DM-Vulcan Gold @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 12
+initial_exposure_time = 30
+material_type = Casting
+material_vendor = 3DM
+material_colour = #B0B000
+
+[sla_material:3DM-TOUGH Clear @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = 3DM
+material_colour = #F8F8F8
+
+[sla_material:3DM-HR Red Wine @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 14
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = 3DM
+material_colour = #EC0000
+
+[sla_material:BlueCast Phrozen Wax @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 15
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #007EFD
+
+[sla_material:BlueCast Castable Wax @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 35
+material_type = Casting
+material_vendor = BlueCast
+material_colour = #007EFD
+
+[sla_material:BlueCast EcoGray @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #808080
+
+[sla_material:BlueCast Kera Master Dental @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 45
+material_type = Medical
+material_vendor = BlueCast
+material_colour = #B0B000
+
+[sla_material:BlueCast Model Dental Gray @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Medical
+material_vendor = BlueCast
+material_colour = #C0C0C0
+
+[sla_material:BlueCast X10 @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 100
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #007EFD
+
+[sla_material:BlueCast X-One @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 25
+initial_exposure_time = 35
+material_type = Casting
+material_vendor = BlueCast
+material_colour = #C0C0C0
+
+[sla_material:DruckWege Type D High Temp @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = DruckWege
+material_colour = #E800E8
+
+[sla_material:Esun Bio-Photopolymer Resin White @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Esun
+material_colour = #FFFFFF
+
+[sla_material:FunToDo Castable Blend Red @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 35
+material_type = Casting
+material_vendor = FunToDo
+material_colour = #EC0000
+
+[sla_material:FunToDo Snow White @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = FunToDo
+material_colour = #FFFFFF
+
+[sla_material:Harz Labs Basic Resin Red @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Harz Labs
+material_colour = #EC0000
+
+[sla_material:Harz Labs Model Resin Cherry @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Harz Labs
+material_colour = #EC0000
+
+[sla_material:Harz Labs Model Resin Black @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Harz Labs
+material_colour = #595959
+
+[sla_material:Harz Labs Dental Cast Red @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 20
+material_type = Medical
+material_vendor = Harz Labs
+material_colour = #EC0000
+
+[sla_material:Esun Standard Resin Black @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Esun
+material_colour = #595959
+
+[sla_material:Photocentric Ash Grey @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Photocentric
+material_colour = #C0C0C0
+
+[sla_material:Resinworks 3D Violet @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 15
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Resinworks 3D
+material_colour = #E800E8
+
+[sla_material:Resinworks 3D Green @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 17
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Resinworks 3D
+material_colour = #00B900
+
+[sla_material:Monocure 3D Black Rapid Resin @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Monocure
+material_colour = #595959
+
+[sla_material:Monocure 3D Blue Rapid Resin @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Monocure
+material_colour = #007EFD
+  
+## Prusa Polymers 0.025
+
+[sla_material:Prusament Resin Tough Prusa Orange @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF8040
+
+[sla_material:Prusament Resin Tough Rich Black @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Tough Anthracite Grey @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #808080
+
+[sla_material:Prusament Resin Tough Sandstone Model @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EEA061
+
+[sla_material:Prusament Resin Tough Terra Brown @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #7A5C45
+
+[sla_material:Prusament Resin Tough Brick Red @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #B46056
+
+[sla_material:Prusament Resin Tough Grass Green @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #37823F
+
+[sla_material:Prusament Resin Tough Bright Yellow @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #F9DB4C
+
+[sla_material:Prusament Resin Tough Transparent Green @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #1DAf5E
+
+[sla_material:Prusament Resin Tough Transparent Red @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D21B31
+
+[sla_material:Prusament Resin Tough Transparent Amber @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FCB30E
+
+[sla_material:Prusament Resin Tough Classic Red @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 3
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EC0000
+
+[sla_material:Prusament Resin Model Solid Grey @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4.5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #9C9D9D
+
+[sla_material:Prusament Resin Model Alabaster White @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4.5
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D6D7D8
+
+[sla_material:Prusament Resin Model Neutral Beige @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4.8
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #BF9C87
+
+[sla_material:Prusament Resin Model Ultra Violet @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #413A7A
+
+[sla_material:Prusament Resin BioBased60 Herbal Green @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #3AD200
+
+[sla_material:Prusament Resin BioBased60 Magma Red @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D20202
+
+[sla_material:Prusament Resin BioBased60 Natural Yellow @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #ECDE05
+
+[sla_material:Prusament Resin BioBased60 Obsidian Black @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #232323
+
+[sla_material:Prusament Resin BioBased60 Sapphire Blue @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 7.7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #2196F3
+
+[sla_material:Prusament Resin BioBased60 Ivory White @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 7.5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #E3D99F
+
+[sla_material:Prusament Resin Flex80 Transparent Clear @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 30
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #F3F6F4
+
+[sla_material:Prusament Resin Flex80 Black @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 30
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Flex80 White @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 5.5
+initial_exposure_time = 35
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #E2D3DB
+
+[sla_material:Ameralabs TGM-7 LED @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Ameralabs
+material_colour = #C0C0C0
+
+[sla_material:PrimaCreator Tough Light Grey @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #C0C0C0
+
+[sla_material:PrimaCreator Tough Clear @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:PrimaCreator Tough White @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #FFFFFF
+
+[sla_material:PrimaCreator Flex Clear @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4.5
+initial_exposure_time = 30
+material_type = Flexible
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Simple Clear @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Blu Clear V2 @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Blu Blue @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #007EFD
+
+[sla_material:Siraya Tech Fast Grey @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #C0C0C0
+
+[sla_material:Siraya Tech Tenacious @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Easy @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 11
+initial_exposure_time = 15
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Sculpt @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #C0C0C0
+
+[sla_material:Siraya Tech Fast Black @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #007EFD
+
+[sla_material:NextDent Model 2.0 Grey @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 14
+initial_exposure_time = 35
+material_type = Medical
+material_vendor = NextDent
+material_colour = #808080
+
+[sla_material:NextDent Surgical Guide @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Medical
+material_vendor = NextDent
+material_colour = #FF8040
+
+[sla_material:NextDent Cast Purple @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 20
+material_type = Casting
+material_vendor = NextDent
+material_colour = #E800E8
+
+[sla_material:MakerJuice Labs Standard Red @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = MakerJuice Labs
+material_colour = #EC0000
+
+[sla_material:3DJake High Precision Grey @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 8.5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = 3DJake
+material_colour = #C0C0C0
+
+[sla_material:3DJake High Precision Blue @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 6.5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = 3DJake
+material_colour = #007EFD
+
+[sla_material:Zortrax Black @0.025]
+inherits = *common 0.025*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Zortrax
+material_colour = #595959
+
+########### Materials 0.05
+
+[sla_material:Asiga Denta Model @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 15
+initial_exposure_time = 30
+material_type = Medical
+material_vendor = Asiga
+material_colour = #FFEEE6
+
+[sla_material:Asiga PlasGRAY @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 29
+initial_exposure_time = 60
+material_type = Tough
+material_vendor = Asiga
+material_colour = #C0C0C0
+
+[sla_material:Ameralabs TGM-7 LED @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Ameralabs
+material_colour = #C0C0C0
+
+[sla_material:Ameralabs AMD 3 LED @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Ameralabs
+material_colour = #808080
+
+[sla_material:BlueCast EcoGray @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #808080
+
+[sla_material:BlueCast Kera Master Dental @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 50
+material_type = Medical
+material_vendor = BlueCast
+material_colour = #FFEEE6
+
+[sla_material:BlueCast Model Dental Gray @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 35
+material_type = Medical
+material_vendor = BlueCast
+material_colour = #C0C0C0
+
+[sla_material:BlueCast LCD-DLP Original @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 60
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #007EFD
+
+[sla_material:BlueCast Phrozen Wax @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 16
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #007EFD
+
+[sla_material:BlueCast Castable Wax @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 11
+initial_exposure_time = 35
+material_type = Casting
+material_vendor = BlueCast
+material_colour = #E800E8
+
+[sla_material:BlueCast S+ @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #00B900
+
+[sla_material:BlueCast X5 @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 100
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #007EFD
+
+[sla_material:BlueCast X10 @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 100
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #007EFD
+
+[sla_material:BlueCast 23LS @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #007EFD
+
+[sla_material:BlueCast X-One @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 27
+initial_exposure_time = 35
+material_type = Casting
+material_vendor = BlueCast
+material_colour = #C0C0C0
+
+[sla_material:DruckWege Type D High Temp @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = DruckWege
+material_colour = #E800E8
+
+[sla_material:Monocure 3D Black Rapid Resin @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Monocure
+material_colour = #595959
+
+[sla_material:Monocure 3D Blue Rapid Resin @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Monocure
+material_colour = #007EFD
+
+[sla_material:Monocure 3D Clear Rapid Resin @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Monocure
+material_colour = #F8F8F8
+
+[sla_material:Monocure 3D Grey Rapid Resin @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Monocure
+material_colour = #C0C0C0
+
+[sla_material:Monocure 3D White Rapid Resin @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Monocure
+material_colour = #FFFFFF
+
+[sla_material:3DM-HTR140 (high temperature) @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 12
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = 3DM
+material_colour = #EC0000
+
+[sla_material:Esun Bio-Photopolymer Resin White @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Esun
+material_colour = #FFFFFF
+
+[sla_material:Esun Standard Resin Black @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Esun
+material_colour = #595959
+
+[sla_material:FunToDo Castable Blend Red @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 15
+initial_exposure_time = 35
+material_type = Casting
+material_vendor = FunToDo
+material_colour = #EC0000
+
+[sla_material:FunToDo Industrial Blend Unpigmented @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = FunToDo
+material_colour = #F8F8F8
+
+[sla_material:FunToDo Snow White @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = FunToDo
+material_colour = #FFFFFF
+
+[sla_material:3DM-ABS @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DM
+material_colour = #FF8040
+
+[sla_material:3DM-BLACK @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 20
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = 3DM
+material_colour = #595959
+
+[sla_material:3DM-DENT @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 45
+material_type = Medical
+material_vendor = 3DM
+material_colour = #FFEEE6
+
+[sla_material:3DM-HR Green @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 15
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = 3DM
+material_colour = #00B900
+
+[sla_material:3DM-HR Red Wine @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 18
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = 3DM
+material_colour = #EC0000
+
+[sla_material:3DM-XPRO White @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = 3DM
+material_colour = #FFFFFF
+
+[sla_material:3DM-Vulcan Gold @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 15
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = 3DM
+material_colour = #B0B000
+
+[sla_material:3DM-TOUGH Clear @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 15
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = 3DM
+material_colour = #F8F8F8
+
+[sla_material:FunToDo Ash Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = FunToDo
+material_colour = #808080
+
+[sla_material:Harz Labs Model Resin Cherry @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Harz Labs
+material_colour = #EC0000
+
+[sla_material:Harz Labs Basic Resin Red @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Harz Labs
+material_colour = #EC0000
+
+[sla_material:Harz Labs Model Resin Black @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Harz Labs
+material_colour = #595959
+
+[sla_material:Harz Labs Dental Cast Red @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 20
+material_type = Medical
+material_vendor = Harz Labs
+material_colour = #EC0000
+
+[sla_material:Resinworks 3D Violet @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 17
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Resinworks 3D
+material_colour = #E800E8
+
+[sla_material:Resinworks 3D Green @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 21
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Resinworks 3D
+material_colour = #00B900
+
+[sla_material:Photocentric Hard Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 15
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Photocentric
+material_colour = #808080
+
+[sla_material:Photocentric Ash Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Photocentric
+material_colour = #C0C0C0
+
+[sla_material:PrimaCreator Tough Light Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8.5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #C0C0C0
+
+[sla_material:PrimaCreator Tough Clear @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:PrimaCreator Tough White @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7.5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #FFFFFF
+
+[sla_material:PrimaCreator Flex Clear @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6.5
+initial_exposure_time = 30
+material_type = Flexible
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Simple Clear @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Blu Clear V2 @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Blu Blue @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 12
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #007EFD
+
+[sla_material:Siraya Tech Fast Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #C0C0C0
+
+[sla_material:Siraya Tech Tenacious @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Easy @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 12
+initial_exposure_time = 15
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Sculpt @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #C0C0C0
+
+[sla_material:Siraya Tech Fast Black @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #595959
+
+[sla_material:NextDent Model 2.0 Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 12
+initial_exposure_time = 35
+material_type = Medical
+material_vendor = NextDent
+material_colour = #C0C0C0
+
+[sla_material:NextDent Surgical Guide @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Medical
+material_vendor = NextDent
+material_colour = #FFEEE6
+
+[sla_material:NextDent Cast Purple @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 20
+material_type = Casting
+material_vendor = NextDent
+material_colour = #E800E8
+
+[sla_material:NextDent Crown Bridge @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 11
+initial_exposure_time = 35
+material_type = Medical
+material_vendor = NextDent
+material_colour = #FFFFFF
+
+[sla_material:MakerJuice Labs Standard Red @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = MakerJuice Labs
+material_colour = #EC0000
+
+[sla_material:3DJake High Precision Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = 3DJake
+material_colour = #C0C0C0
+
+[sla_material:3DJake High Precision Blue @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = 3DJake
+material_colour = #007EFD
+
+[sla_material:Dragon Resin Metalshine Metal Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 30
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = Dragon Resin
+material_colour = #808080
+
+[sla_material:Dragon Resin Metalshine Dark Brass @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 30
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = Dragon Resin
+material_colour = #B0B000
+
+[sla_material:Dragon Resin Metalshine Brass @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 30
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = Dragon Resin
+material_colour = #B0B000
+
+[sla_material:Zortrax Black @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Zortrax
+material_colour = #595959
+
+## Prusa Polymers 0.05
+
+[sla_material:Prusament Resin Tough Prusa Orange @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF8040
+
+[sla_material:Prusament Resin Tough Rich Black @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Tough Anthracite Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #C0C0C0
+
+[sla_material:Prusament Resin Tough Sandstone Model @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EEA061
+
+[sla_material:Prusament Resin Tough Terra Brown @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #7A5C45
+
+[sla_material:Prusament Resin Tough Brick Red @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #B46056
+
+[sla_material:Prusament Resin Tough Grass Green @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #37823F
+
+[sla_material:Prusament Resin Tough Bright Yellow @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #F9DB4C
+
+[sla_material:Prusament Resin Tough Transparent Green @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #1DAf5E
+
+[sla_material:Prusament Resin Tough Transparent Red @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D21B31
+
+[sla_material:Prusament Resin Tough Transparent Amber @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FCB30E
+
+[sla_material:Prusament Resin Tough Classic Red @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 4
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EC0000
+
+[sla_material:Prusament Resin Model Solid Grey @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #9C9D9D
+
+[sla_material:Prusament Resin Model Alabaster White @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 5
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D6D7D8
+
+[sla_material:Prusament Resin Model Neutral Beige @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 5.5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #BF9C87
+
+[sla_material:Prusament Resin Model Ultra Violet @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #413A7A
+
+[sla_material:Prusament Resin BioBased60 Herbal Green @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #3AD200
+
+[sla_material:Prusament Resin BioBased60 Magma Red @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D20202
+
+[sla_material:Prusament Resin BioBased60 Natural Yellow @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #ECDE05
+
+[sla_material:Prusament Resin BioBased60 Obsidian Black @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 12
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #232323
+
+[sla_material:Prusament Resin BioBased60 Sapphire Blue @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #2196F3
+
+[sla_material:Prusament Resin BioBased60 Ivory White @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 9.5
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #E3D99F
+
+[sla_material:Prusament Resin Flex80 Transparent Clear @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 15
+initial_exposure_time = 30
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #F3F6F4
+
+[sla_material:Prusament Resin Flex80 Black @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 30
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Flex80 White @0.05]
+inherits = *common 0.05*; *sl1_fast*
+exposure_time = 6.5
+initial_exposure_time = 35
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #E2D3DB
+
+########### Materials 0.1
+
+[sla_material:BlueCast EcoGray @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #C0C0C0
+
+[sla_material:BlueCast Kera Master Dental @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #FFEEE6
+
+[sla_material:BlueCast X-One @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 30
+initial_exposure_time = 45
+material_type = Casting
+material_vendor = BlueCast
+material_colour = #C0C0C0
+
+[sla_material:Ameralabs TGM-7 LED @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 10
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Ameralabs
+material_colour = #C0C0C0
+
+## Prusa Polymers 0.1
+
+[sla_material:Prusament Resin Tough Prusa Orange @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF8040
+
+[sla_material:Prusament Resin Tough Rich Black @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Tough Anthracite Grey @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 14
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #808080
+
+[sla_material:Prusament Resin Tough Classic Red @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 6
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EC0000
+
+[sla_material:Prusament Resin Tough Sandstone Model @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EEA061
+
+[sla_material:Prusament Resin Tough Terra Brown @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #7A5C45
+
+[sla_material:Prusament Resin Tough Brick Red @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #B46056
+
+[sla_material:Prusament Resin Tough Grass Green @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #37823F
+
+[sla_material:Prusament Resin Tough Bright Yellow @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #F9DB4C
+
+[sla_material:Prusament Resin Tough Transparent Green @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #1DAf5E
+
+[sla_material:Prusament Resin Tough Transparent Red @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D21B31
+
+[sla_material:Prusament Resin Tough Transparent Amber @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FCB30E
+
+[sla_material:Prusament Resin BioBased60 Herbal Green @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #3AD200
+
+[sla_material:Prusament Resin Model Solid Grey @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #9C9D9D
+
+[sla_material:Prusament Resin Model Alabaster White @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D6D7D8
+
+[sla_material:Prusament Resin Model Neutral Beige @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #BF9C87
+
+[sla_material:Prusament Resin Model Ultra Violet @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 7
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #413A7A
+
+[sla_material:Prusament Resin BioBased60 Magma Red @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D20202
+
+[sla_material:Prusament Resin BioBased60 Natural Yellow @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 8
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #ECDE05
+
+[sla_material:Prusament Resin BioBased60 Obsidian Black @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 16
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #232323
+
+[sla_material:Prusament Resin BioBased60 Sapphire Blue @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 9
+initial_exposure_time = 35
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #2196F3
+
+[sla_material:Prusament Resin BioBased60 Ivory White @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 12
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #E3D99F
+
+[sla_material:Prusament Resin Flex80 Transparent Clear @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 20
+initial_exposure_time = 30
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #F3F6F4
+
+[sla_material:Prusament Resin Flex80 Black @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 30
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Flex80 White @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 7.5
+initial_exposure_time = 45
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #E2D3DB
+
+[sla_material:PrimaCreator Tough Light Grey @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 14
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #C0C0C0
+
+[sla_material:PrimaCreator Tough Clear @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:PrimaCreator Tough White @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 13
+initial_exposure_time = 45
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #FFFFFF
+
+[sla_material:PrimaCreator Flex Clear @0.1]
+inherits = *common 0.1*; *sl1_fast*
+exposure_time = 12
+initial_exposure_time = 35
+material_type = Flexible
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+## SL1S materials ##
+
+## 0.025 SL1S
+
+## Prusa Polymers 0.025
+
+[sla_material:Prusament Resin Tough Prusa Orange @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF8040
+
+[sla_material:Prusament Resin Tough Rich Black @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Tough Anthracite Grey @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #808080
+
+[sla_material:Prusament Resin Tough Sandstone Model @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EEA061
+
+[sla_material:Prusament Resin Tough Terra Brown @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #7A5C45
+
+[sla_material:Prusament Resin Tough Brick Red @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #B46056
+
+[sla_material:Prusament Resin Tough Grass Green @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #37823F
+
+[sla_material:Prusament Resin Tough Bright Yellow @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #F9DB4C
+
+[sla_material:Prusament Resin Tough Transparent Green @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #1DAf5E
+
+[sla_material:Prusament Resin Tough Transparent Red @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D21B31
+
+[sla_material:Prusament Resin Tough Transparent Amber @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FCB30E
+
+[sla_material:Prusament Resin Tough Classic Red @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EC0000
+
+[sla_material:Prusament Resin Model Anthracite Grey @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*
+exposure_time = 1.8
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #808080
+
+[sla_material:Prusament Resin Model Classic Red @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*
+exposure_time = 1.8
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EC0000
+
+[sla_material:Prusament Resin Model Solid Grey @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #9C9D9D
+
+[sla_material:Prusament Resin Model Rich Black @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Model Bright Cyan @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #0079A7
+
+[sla_material:Prusament Resin Model Bright Magenta @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.9
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF0066
+
+[sla_material:Prusament Resin Model Bright Yellow @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #C7B91F
+
+[sla_material:Prusament Resin Model Grass Green @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #37823F
+
+[sla_material:Prusament Resin Model Prusa Orange @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF8040
+
+[sla_material:Prusament Resin Model Transparent Amber @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FFC107
+
+[sla_material:Prusament Resin Model Transparent Green @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.6
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #1DAf5E
+
+[sla_material:Prusament Resin Model Transparent Red @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D21B31
+
+[sla_material:Prusament Resin Model Alabaster White @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D6D7D8
+
+[sla_material:Prusament Resin Model Neutral Beige @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #BF9C87
+
+[sla_material:Prusament Resin Model Ultra Violet @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #413A7A
+
+[sla_material:Prusament Resin Model Transparent Clear @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 10
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #F3F6F4
+
+[sla_material:Prusament Resin Model Sandstone @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EEA061
+
+[sla_material:Prusament Resin Model Terra Brown @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #7A5C45
+
+[sla_material:Prusament Resin Model Brick Red @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #B46056
+
+[sla_material:Prusament Resin BioBased60 Herbal Green @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.5
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #3AD200
+
+[sla_material:Prusament Resin BioBased60 Magma Red @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.5
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D20202
+
+[sla_material:Prusament Resin BioBased60 Natural Yellow @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 2.8
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #ECDE05
+material_print_speed = slow
+
+[sla_material:Prusament Resin BioBased60 Obsidian Black @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #232323
+
+[sla_material:Prusament Resin BioBased60 Sapphire Blue @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #2196F3
+
+[sla_material:Prusament Resin BioBased60 Ivory White @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #E3D99F
+
+[sla_material:Prusament Resin Flex80 Transparent Clear @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 4
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #F3F6F4
+material_print_speed = slow
+
+[sla_material:Prusament Resin Flex80 Black @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #595959
+material_print_speed = slow
+
+[sla_material:Prusament Resin Flex80 White @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 17
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #E2D3DB
+
+[sla_material:Prusament Resin Flex Anatomic Red @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 2.6
+initial_exposure_time = 20
+material_type = Medical
+material_vendor = Prusa Polymers
+material_colour = #AD4F54
+
+[sla_material:Prusament Resin Flex Gingiva Mask @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 2.6
+initial_exposure_time = 20
+material_type = Medical
+material_vendor = Prusa Polymers
+material_colour = #DB7F80
+
+[sla_material:Ameralabs TGM-7 LED @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Ameralabs
+material_colour = #C0C0C0
+material_print_speed = slow
+
+[sla_material:BASF Ultracur3D RG 35 @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #FFEEE6
+
+[sla_material:BASF Ultracur3D ST 45 @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D ST 45 M @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D ST 80 @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #FFEEE6
+
+[sla_material:BASF Ultracur3D ST 80 White @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #FFFFFF
+
+[sla_material:BASF Ultracur3D ST 80 Black @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D EL 150 Black @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D FL 300 Black @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BlueCast X-One @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 6
+initial_exposure_time = 25
+material_type = Casting
+material_vendor = BlueCast
+material_colour = #C0C0C0
+material_print_speed = slow
+
+[sla_material:PrimaCreator Tough Light Grey @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #C0C0C0
+
+[sla_material:PrimaCreator Tough Clear @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:PrimaCreator Tough White @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #FFFFFF
+
+[sla_material:PrimaCreator Flex Clear @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:PrimaCreator Water Washable Transparent @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:DruckWege Type D Dental Model @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 1.2
+initial_exposure_time = 15
+material_type = Medical
+material_vendor = DruckWege
+material_colour = #FFEEE6
+material_print_speed = slow
+
+[sla_material:DruckWege Type D Standard White @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 1.6
+initial_exposure_time = 15
+material_type = Tough
+material_vendor = DruckWege
+material_colour = #FFFFFF
+material_print_speed = slow
+
+[sla_material:DruckWege Type D Standard Pigmentfrei Clear @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 1.8
+initial_exposure_time = 15
+material_type = Tough
+material_vendor = DruckWege
+material_colour = #F8F8F8
+material_print_speed = slow
+
+[sla_material:3DM-ABS Orange @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DM
+material_colour = #FF8040
+
+[sla_material:3DM-TOUGH Clear @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DM
+material_colour = #F8F8F8
+
+[sla_material:Peopoly Deft White @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Peopoly
+material_colour = #FFFFFF
+
+[sla_material:Peopoly Neo Clear @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Peopoly
+material_colour = #F8F8F8
+
+[sla_material:Liqcreate Clear Impact @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 7
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #F8F8F8
+
+[sla_material:Liqcreate Premium Model @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.7
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #BF9C87
+material_correction_x = 1.0073
+material_correction_y = 1.0073
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Strong X @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 7
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #C0C0C0
+
+[sla_material:Liqcreate Wax Castable @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_slow*
+exposure_time = 3.5
+initial_exposure_time = 20
+material_type = Casting
+material_vendor = Liqcreate
+material_colour = #007EFD
+material_correction_x = 1.02
+material_correction_y = 1.02
+material_ow_support_pillar_diameter = 1
+material_ow_support_head_front_diameter = 0.5
+material_ow_support_head_penetration = 0.5
+material_ow_support_head_width = 3
+
+[sla_material:Resinworks 3D Green @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Resinworks 3D
+material_colour = #00B900
+
+[sla_material:3DJake Blue @0.025 SL1S]
+inherits = *0.025_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DJake
+material_colour = #007EFD
+
+## 0.05 SL1S
+
+## Prusa Polymers 0.05
+
+[sla_material:Prusament Resin Tough Prusa Orange @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF8040
+
+[sla_material:Prusament Resin Tough Rich Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Tough Anthracite Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.4
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #808080
+
+[sla_material:Prusament Resin Tough Sandstone Model @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.4
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EEA061
+
+[sla_material:Prusament Resin Tough Terra Brown @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #7A5C45
+
+
+[sla_material:Prusament Resin Tough Brick Red @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #B46056
+
+[sla_material:Prusament Resin Tough Grass Green @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #37823F
+
+[sla_material:Prusament Resin Tough Bright Yellow @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #F9DB4C
+
+[sla_material:Prusament Resin Tough Transparent Green @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #1DAf5E
+
+[sla_material:Prusament Resin Tough Transparent Red @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D21B31
+
+[sla_material:Prusament Resin Tough Transparent Amber @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FCB30E
+
+[sla_material:Prusament Resin Tough Classic Red @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EC0000
+
+[sla_material:Prusament Resin Model Anthracite Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*
+exposure_time = 2
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #808080
+
+[sla_material:Prusament Resin Model Classic Red @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*
+exposure_time = 2
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EC0000
+
+[sla_material:Prusament Resin Model Solid Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #9C9D9D
+
+[sla_material:Prusament Resin Model Rich Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Model Bright Cyan @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #0079A7
+
+[sla_material:Prusament Resin Model Bright Magenta @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF0066
+
+[sla_material:Prusament Resin Model Grass Green @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #37823F
+
+[sla_material:Prusament Resin Model Prusa Orange @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF8040
+
+[sla_material:Prusament Resin Model Bright Yellow @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.4
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #C7B91F
+
+[sla_material:Prusament Resin Model Transparent Amber @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FFC107
+
+[sla_material:Prusament Resin Model Transparent Green @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #1DAf5E
+
+[sla_material:Prusament Resin Model Transparent Red @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D21B31
+
+[sla_material:Prusament Resin Model Alabaster White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D6D7D8
+
+[sla_material:Prusament Resin Model Neutral Beige @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #BF9C87
+
+[sla_material:Prusament Resin Model Ultra Violet @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #413A7A
+
+[sla_material:Prusament Resin Model Transparent Clear @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.5
+initial_exposure_time = 10
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #F3F6F4
+
+[sla_material:Prusament Resin Model Sandstone @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EEA061
+
+[sla_material:Prusament Resin Model Terra Brown @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #7A5C45
+
+[sla_material:Prusament Resin Model Brick Red @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.2
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #B46056
+
+[sla_material:Prusament Resin BioBased60 Herbal Green @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #3AD200
+
+[sla_material:Prusament Resin BioBased60 Magma Red @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D20202
+
+[sla_material:Prusament Resin BioBased60 Natural Yellow @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 3
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #ECDE05
+material_print_speed = slow
+
+[sla_material:Prusament Resin BioBased60 Obsidian Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #232323
+
+[sla_material:Prusament Resin BioBased60 Sapphire Blue @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #2196F3
+
+[sla_material:Prusament Resin BioBased60 Ivory White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.5
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #E3D99F
+
+[sla_material:Prusament Resin Flex80 Transparent Clear @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 5
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #F3F6F4
+material_print_speed = slow
+
+[sla_material:Prusament Resin Flex80 Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #595959
+material_print_speed = slow
+
+[sla_material:Prusament Resin Flex80 White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 17
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #E2D3DB
+
+[sla_material:Prusament Resin Flex Anatomic Red @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 3
+initial_exposure_time = 20
+material_type = Medical
+material_vendor = Prusa Polymers
+material_colour = #AD4F54
+
+[sla_material:Prusament Resin Flex Gingiva Mask @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 3
+initial_exposure_time = 20
+material_type = Medical
+material_vendor = Prusa Polymers
+material_colour = #DB7F80
+
+[sla_material:ALTANA Cubic Ink High Performance 4-1000 VP-V0 @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 11
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Altana
+material_colour = #595959
+material_correction_x = 1.005
+material_correction_y = 1.005
+
+[sla_material:ALTANA Cubic Ink High Performance 4-2100 VP @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4
+initial_exposure_time = 10
+material_type = Tough
+material_vendor = Altana
+material_colour = #595959
+material_correction_x = 1.01
+material_correction_y = 1.01
+zcorrection_layers = 3
+
+[sla_material:ALTANA Cubic Ink High Performance 4-2800 VP-ESD black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 10
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Altana
+material_colour = #595959
+material_correction_x = 1.01
+material_correction_y = 1.01
+
+[sla_material:Ameralabs TGM-7 LED @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Ameralabs
+material_colour = #C0C0C0
+material_print_speed = slow
+
+[sla_material:BASF Ultracur3D RG 35 @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #FFEEE6
+
+[sla_material:BASF Ultracur3D ST 45 @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D ST 45 M @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D ST 80 @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #FFEEE6
+
+[sla_material:BASF Ultracur3D ST 80 White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5.9
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #FFFFFF
+
+[sla_material:BASF Ultracur3D ST 80 Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5.9
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D EL 150 Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.8
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D FL 300 Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.8
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:PrimaCreator Tough Light Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.4
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #C0C0C0
+
+[sla_material:PrimaCreator Tough Clear @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:PrimaCreator Tough White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #FFFFFF
+
+[sla_material:PrimaCreator Flex Clear @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:PrimaCreator Water Washable Transparent @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:DruckWege Type D Dental Model @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 1.4
+initial_exposure_time = 15
+material_type = Medical
+material_vendor = DruckWege
+material_colour = #FFEEE6
+material_print_speed = slow
+
+[sla_material:DruckWege Type D Standard White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 2
+initial_exposure_time = 15
+material_type = Tough
+material_vendor = DruckWege
+material_colour = #FFFFFF
+material_print_speed = slow
+
+[sla_material:DruckWege Type D Standard Pigmentfrei Clear @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 2
+initial_exposure_time = 15
+material_type = Tough
+material_vendor = DruckWege
+material_colour = #F8F8F8
+material_print_speed = slow
+
+[sla_material:3DM-ABS Orange @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DM
+material_colour = #FF8040
+
+[sla_material:3DM-TOUGH Clear @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DM
+material_colour = #F8F8F8
+
+[sla_material:Peopoly Deft White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Peopoly
+material_colour = #FFFFFF
+
+[sla_material:Peopoly Neo Clear @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Peopoly
+material_colour = #F8F8F8
+
+[sla_material:3DM-ABS @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DM
+material_colour = #FF8040
+
+[sla_material:3DM-DENT @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.3
+initial_exposure_time = 36
+material_type = Medical
+material_vendor = 3DM
+material_colour = #FFEEE6
+
+[sla_material:3DM-HR Green @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = 3DM
+material_colour = #00B900
+
+[sla_material:3DM-HR Red Wine @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 6
+initial_exposure_time = 32
+material_type = Tough
+material_vendor = 3DM
+material_colour = #EC0000
+
+[sla_material:3DM-Vulcan Gold @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5
+initial_exposure_time = 24
+material_type = Casting
+material_vendor = 3DM
+material_colour = #B0B000
+
+[sla_material:3DM-XPRO White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = 3DM
+material_colour = #FFFFFF
+
+[sla_material:Asiga Denta Model @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5
+initial_exposure_time = 24
+material_type = Medical
+material_vendor = Asiga
+material_colour = #FFEEE6
+
+[sla_material:Asiga PlasGRAY @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 9.7
+initial_exposure_time = 48
+material_type = Tough
+material_vendor = Asiga
+material_colour = #C0C0C0
+
+[sla_material:BlueCast EcoGray @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.3
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #808080
+
+[sla_material:BlueCast Phrozen Wax @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5.3
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = BlueCast
+material_colour = #007EFD
+
+[sla_material:BlueCast X-One @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 7
+initial_exposure_time = 25
+material_type = Casting
+material_vendor = BlueCast
+material_colour = #C0C0C0
+material_print_speed = slow
+
+[sla_material:NextDent Model 2.0 Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4
+initial_exposure_time = 28
+material_type = Medical
+material_vendor = NextDent
+material_colour = #C0C0C0
+
+[sla_material:NextDent Cast Purple @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 16
+material_type = Casting
+material_vendor = NextDent
+material_colour = #E800E8
+
+[sla_material:Siraya Tech Tenacious @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.7
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Blu Clear V2 @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.3
+initial_exposure_time = 24
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Blu Blue @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #007EFD
+
+[sla_material:Siraya Tech Fast Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #595959
+
+[sla_material:Siraya Tech Fast Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.3
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #C0C0C0
+
+[sla_material:Siraya Tech Simple Clear @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.3
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #F8F8F8
+
+[sla_material:Siraya Tech Sculpt @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.7
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = Siraya Tech
+material_colour = #C0C0C0
+
+[sla_material:Harz Labs Model Resin Cherry @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.3
+initial_exposure_time = 16
+material_type = Tough
+material_vendor = Harz Labs
+material_colour = #EC0000
+
+[sla_material:Harz Labs Model Resin Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.3
+initial_exposure_time = 16
+material_type = Tough
+material_vendor = Harz Labs
+material_colour = #595959
+
+[sla_material:Harz Labs Basic Resin Red @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.3
+initial_exposure_time = 16
+material_type = Tough
+material_vendor = Harz Labs
+material_colour = #EC0000
+
+[sla_material:Resinworks 3D Violet @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5.7
+initial_exposure_time = 24
+material_type = Tough
+material_vendor = Resinworks 3D
+material_colour = #E800E8
+
+[sla_material:FunToDo Industrial Blend Unpigmented @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.3
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = FunToDo
+material_colour = #F8F8F8
+
+[sla_material:FunToDo Snow White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.3
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = FunToDo
+material_colour = #FFFFFF
+
+[sla_material:FunToDo Ash Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 32
+material_type = Tough
+material_vendor = FunToDo
+material_colour = #808080
+
+[sla_material:Ameralabs AMD 3 LED @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 1.7
+initial_exposure_time = 24
+material_type = Tough
+material_vendor = Ameralabs
+material_colour = #808080
+
+[sla_material:Dragon Resin Metalshine Metal Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 10
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Dragon Resin
+material_colour = #808080
+
+[sla_material:Dragon Resin Metalshine Dark Brass @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 10
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Dragon Resin
+material_colour = #B0B000
+
+[sla_material:Dragon Resin Metalshine Brass @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 10
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Dragon Resin
+material_colour = #B0B000
+
+[sla_material:Esun Bio-Photopolymer Resin White @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.7
+initial_exposure_time = 24
+material_type = Tough
+material_vendor = Esun
+material_colour = #FFFFFF
+
+[sla_material:Esun Standard Resin Black @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.3
+initial_exposure_time = 24
+material_type = Tough
+material_vendor = Esun
+material_colour = #595959
+
+[sla_material:Monocure 3D Black Rapid Resin @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = Monocure
+material_colour = #595959
+
+[sla_material:Monocure 3D Blue Rapid Resin @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.3
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = Monocure
+material_colour = #007EFD
+
+[sla_material:Monocure 3D Clear Rapid Resin @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.7
+initial_exposure_time = 32
+material_type = Tough
+material_vendor = Monocure
+material_colour = #F8F8F8
+
+[sla_material:Monocure 3D Grey Rapid Resin @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Monocure
+material_colour = #C0C0C0
+
+[sla_material:Monocure 3D White Rapid Resin @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.3
+initial_exposure_time = 28
+material_type = Tough
+material_vendor = Monocure
+material_colour = #FFFFFF
+
+[sla_material:Photocentric Hard Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5
+initial_exposure_time = 24
+material_type = Tough
+material_vendor = Photocentric
+material_colour = #808080
+
+[sla_material:Liqcreate Bio-Med Clear @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5
+initial_exposure_time = 40
+material_type = Medical
+material_vendor = Liqcreate
+material_colour = #F8F8F8
+material_correction_x = 1.02
+material_correction_y = 1.02
+material_ow_support_pillar_diameter = 1
+material_ow_support_head_front_diameter = 0.5
+material_ow_support_head_penetration = 0.5
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Clear Impact @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 10
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #F8F8F8
+
+[sla_material:Liqcreate Dental Model Pro Beige @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #BF9C87
+material_correction_x = 1.0073
+material_correction_y = 1.0073
+material_ow_support_pillar_diameter = 1
+material_ow_support_head_front_diameter = 0.5
+material_ow_support_head_penetration = 0.5
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Dental Model Pro Grey @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #808080
+material_correction_x = 1.0073
+material_correction_y = 1.0073
+material_ow_support_pillar_diameter = 1
+material_ow_support_head_front_diameter = 0.5
+material_ow_support_head_penetration = 0.5
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Flexible-X @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 15
+initial_exposure_time = 40
+material_type = Flexible
+material_vendor = Liqcreate
+material_colour = #595959
+material_correction_x = 1.01
+material_correction_y = 1.01
+material_ow_support_pillar_diameter = 1.5
+material_ow_support_head_front_diameter = 1
+material_ow_support_head_penetration = 1
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Premium Model @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #BF9C87
+material_correction_x = 1.0073
+material_correction_y = 1.0073
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Strong X @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 10
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #C0C0C0
+
+[sla_material:Liqcreate Tough-X @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 12
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #595959
+material_correction_x = 1.005
+material_correction_y = 1.005
+material_ow_support_pillar_diameter = 1.5
+material_ow_support_head_front_diameter = 1
+material_ow_support_head_penetration = 0.75
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Wax Castable @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_slow*
+exposure_time = 4.5
+initial_exposure_time = 25
+material_type = Casting
+material_vendor = Liqcreate
+material_colour = #007EFD
+material_correction_x = 1.02
+material_correction_y = 1.02
+material_ow_support_pillar_diameter = 1
+material_ow_support_head_front_diameter = 0.5
+material_ow_support_head_penetration = 0.5
+material_ow_support_head_width = 3
+
+[sla_material:Resinworks 3D Green @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 7
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Resinworks 3D
+material_colour = #00B900
+
+[sla_material:3DJake Blue @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DJake
+material_colour = #007EFD
+
+[sla_material:LOCTITE 3D IND475 @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4
+initial_exposure_time = 15
+material_type = Flexible
+material_vendor = Henkel
+material_colour = #FFFFFF
+
+[sla_material:LOCTITE 3D PRO476 @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 7
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Henkel
+material_colour = #595959
+
+[sla_material:LOCTITE 3D 3843 HDT60 High Toughness @0.05 SL1S]
+inherits = *0.05_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 13
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Henkel
+material_colour = #595959
+
+## 0.1 SL1S
+
+## Prusa Polymers 0.1
+
+[sla_material:Prusament Resin Tough Prusa Orange @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF8040
+
+[sla_material:Prusament Resin Tough Rich Black @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Tough Anthracite Grey @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #808080
+
+[sla_material:Prusament Resin Tough Sandstone Model @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EEA061
+
+[sla_material:Prusament Resin Tough Terra Brown @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #7A5C45
+
+[sla_material:Prusament Resin Tough Brick Red @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #B46056
+
+[sla_material:Prusament Resin Tough Grass Green @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #37823F
+
+[sla_material:Prusament Resin Tough Bright Yellow @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #F9DB4C
+
+[sla_material:Prusament Resin Tough Transparent Green @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #1DAf5E
+
+[sla_material:Prusament Resin Tough Transparent Red @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D21B31
+
+[sla_material:Prusament Resin Tough Transparent Amber @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FCB30E
+
+[sla_material:Prusament Resin Tough Classic Red @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EC0000
+
+[sla_material:Prusament Resin Model Anthracite Grey @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*
+exposure_time = 2.6
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #808080
+
+[sla_material:Prusament Resin Model Classic Red @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*
+exposure_time = 2.4
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EC0000
+
+[sla_material:Prusament Resin Model Solid Grey @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #9C9D9D
+
+[sla_material:Prusament Resin Model Rich Black @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #595959
+
+[sla_material:Prusament Resin Model Bright Cyan @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #0079A7
+
+[sla_material:Prusament Resin Model Bright Magenta @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.7
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF0066
+
+[sla_material:Prusament Resin Model Grass Green @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #37823F
+
+[sla_material:Prusament Resin Model Prusa Orange @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FF8040
+
+[sla_material:Prusament Resin Model Bright Yellow @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #C7B91F
+
+[sla_material:Prusament Resin Model Transparent Amber @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #FFC107
+
+[sla_material:Prusament Resin Model Transparent Green @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.4
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #1DAf5E
+
+[sla_material:Prusament Resin Model Transparent Red @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.4
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D21B31
+
+[sla_material:Prusament Resin Model Alabaster White @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.8
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D6D7D8
+
+[sla_material:Prusament Resin Model Neutral Beige @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.8
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #BF9C87
+
+[sla_material:Prusament Resin Model Ultra Violet @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #413A7A
+
+[sla_material:Prusament Resin Model Transparent Clear @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 3.2
+initial_exposure_time = 10
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #F3F6F4
+material_print_speed = slow
+
+[sla_material:Prusament Resin Model Sandstone @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.4
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #EEA061
+
+[sla_material:Prusament Resin Model Terra Brown @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.4
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #7A5C45
+
+[sla_material:Prusament Resin Model Brick Red @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 18
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #B46056
+
+[sla_material:Prusament Resin BioBased60 Herbal Green @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #3AD200
+
+[sla_material:Prusament Resin BioBased60 Magma Red @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #D20202
+
+[sla_material:Prusament Resin BioBased60 Natural Yellow @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 4
+initial_exposure_time = 30
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #ECDE05
+material_print_speed = slow
+
+[sla_material:Prusament Resin BioBased60 Obsidian Black @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 7.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #232323
+
+[sla_material:Prusament Resin BioBased60 Sapphire Blue @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #2196F3
+
+[sla_material:Prusament Resin BioBased60 Ivory White @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = Prusa Polymers
+material_colour = #E3D99F
+
+[sla_material:Prusament Resin Flex80 Transparent Clear @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 6
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #F3F6F4
+material_print_speed = slow
+
+[sla_material:Prusament Resin Flex80 Black @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 3.5
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #595959
+material_print_speed = slow
+
+[sla_material:Prusament Resin Flex80 White @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3.5
+initial_exposure_time = 17
+material_type = Flexible
+material_vendor = Prusa Polymers
+material_colour = #E2D3DB
+
+[sla_material:Prusament Resin Flex Anatomic Red @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 3.5
+initial_exposure_time = 20
+material_type = Medical
+material_vendor = Prusa Polymers
+material_colour = #AD4F54
+
+[sla_material:Prusament Resin Flex Gingiva Mask @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 3.5
+initial_exposure_time = 20
+material_type = Medical
+material_vendor = Prusa Polymers
+material_colour = #DB7F80
+
+[sla_material:ALTANA Cubic Ink High Performance 4-1000 VP-V0 @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 12
+initial_exposure_time = 20
+material_type = Tough
+material_vendor = Altana
+material_colour = #595959
+material_correction_x = 1.008
+material_correction_y = 1.008
+
+[sla_material:ALTANA Cubic Ink High Performance 4-2100 VP @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 10
+material_type = Tough
+material_vendor = Altana
+material_colour = #595959
+material_correction_x = 1.015
+material_correction_y = 1.015
+zcorrection_layers = 1
+
+[sla_material:ALTANA Cubic Ink High Performance 4-2800 VP-ESD black @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 11
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Altana
+material_colour = #595959
+material_correction_x = 1.01
+material_correction_y = 1.01
+
+[sla_material:Ameralabs TGM-7 LED @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Ameralabs
+material_colour = #C0C0C0
+material_print_speed = slow
+
+[sla_material:BASF Ultracur3D RG 35 @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 10
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #FFEEE6
+
+[sla_material:BASF Ultracur3D ST 45 @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 7.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D ST 45 M @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D ST 80 @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 9
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #FFEEE6
+
+[sla_material:BASF Ultracur3D ST 80 White @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 9
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #FFFFFF
+
+[sla_material:BASF Ultracur3D ST 80 Black @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 9
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D EL 150 Black @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BASF Ultracur3D FL 300 Black @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 6
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = BASF
+material_colour = #595959
+
+[sla_material:BlueCast X-One @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 8.5
+initial_exposure_time = 25
+material_type = Casting
+material_vendor = BlueCast
+material_colour = #C0C0C0
+material_print_speed = slow
+
+[sla_material:PrimaCreator Tough Light Grey @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #C0C0C0
+
+[sla_material:PrimaCreator Tough Clear @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:PrimaCreator Tough White @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #FFFFFF
+
+[sla_material:PrimaCreator Flex Clear @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Flexible
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:PrimaCreator Water Washable Transparent @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = PrimaCreator
+material_colour = #F8F8F8
+
+[sla_material:DruckWege Type D Dental Model @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 2.6
+initial_exposure_time = 15
+material_type = Medical
+material_vendor = DruckWege
+material_colour = #FFEEE6
+material_print_speed = slow
+
+[sla_material:3DM-ABS Orange @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DM
+material_colour = #FF8040
+
+[sla_material:3DM-TOUGH Clear @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DM
+material_colour = #F8F8F8
+
+[sla_material:Peopoly Deft White @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Peopoly
+material_colour = #FFFFFF
+
+[sla_material:Peopoly Neo Clear @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 2.6
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Peopoly
+material_colour = #F8F8F8
+
+[sla_material:Liqcreate Bio-Med Clear @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 8
+initial_exposure_time = 60
+material_type = Medical
+material_vendor = Liqcreate
+material_colour = #F8F8F8
+material_correction_x = 1.02
+material_correction_y = 1.02
+material_ow_support_pillar_diameter = 1
+material_ow_support_head_front_diameter = 0.5
+material_ow_support_head_penetration = 0.5
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Clear Impact @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 20
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #F8F8F8
+
+[sla_material:Liqcreate Dental Model Pro Beige @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #BF9C87
+material_correction_x = 1.0073
+material_correction_y = 1.0073
+material_ow_support_pillar_diameter = 1
+material_ow_support_head_front_diameter = 0.5
+material_ow_support_head_penetration = 0.5
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Dental Model Pro Grey @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 5.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #808080
+material_correction_x = 1.0073
+material_correction_y = 1.0073
+material_ow_support_pillar_diameter = 1
+material_ow_support_head_front_diameter = 0.5
+material_ow_support_head_penetration = 0.5
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Flexible-X @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 17
+initial_exposure_time = 40
+material_type = Flexible
+material_vendor = Liqcreate
+material_colour = #595959
+material_correction_x = 1.01
+material_correction_y = 1.01
+material_ow_support_pillar_diameter = 1.5
+material_ow_support_head_front_diameter = 1
+material_ow_support_head_penetration = 1
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Premium Model @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 4.5
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #BF9C87
+material_correction_x = 1.0073
+material_correction_y = 1.0073
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Strong X @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 20
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #C0C0C0
+
+[sla_material:Liqcreate Tough-X @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 15
+initial_exposure_time = 50
+material_type = Tough
+material_vendor = Liqcreate
+material_colour = #595959
+material_correction_x = 1.005
+material_correction_y = 1.005
+material_ow_support_pillar_diameter = 1.5
+material_ow_support_head_front_diameter = 1
+material_ow_support_head_penetration = 0.75
+material_ow_support_head_width = 3
+
+[sla_material:Liqcreate Wax Castable @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_slow*
+exposure_time = 5.5
+initial_exposure_time = 30
+material_type = Casting
+material_vendor = Liqcreate
+material_colour = #007EFD
+material_correction_x = 1.02
+material_correction_y = 1.02
+material_ow_support_pillar_diameter = 1
+material_ow_support_head_front_diameter = 0.5
+material_ow_support_head_penetration = 0.5
+material_ow_support_head_width = 3
+
+[sla_material:Resinworks 3D Green @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 13
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Resinworks 3D
+material_colour = #00B900
+
+[sla_material:3DJake Blue @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 3
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = 3DJake
+material_colour = #007EFD
+
+[sla_material:LOCTITE 3D IND475 @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 6.5
+initial_exposure_time = 15
+material_type = Flexible
+material_vendor = Henkel
+material_colour = #FFFFFF
+
+[sla_material:LOCTITE 3D PRO476 @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 9
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Henkel
+material_colour = #595959
+
+[sla_material:LOCTITE 3D 3843 HDT60 High Toughness @0.1 SL1S]
+inherits = *0.1_sl1s*; *sl1s_fast*; *legacy_fast*
+exposure_time = 18
+initial_exposure_time = 25
+material_type = Tough
+material_vendor = Henkel
+material_colour = #595959
+
+# Printer presets
+
+[printer:Original Prusa SL1]
+printer_technology = SLA
+printer_model = SL1
+printer_variant = default
+default_sla_material_profile = Prusa Orange Tough @0.05
+default_sla_print_profile = 0.05 Normal
+thumbnails = 400x400,800x480
+bed_shape = 1.48x1.02,119.48x1.02,119.48x67.02,1.48x67.02
+display_height = 68.04
+display_orientation = portrait
+display_pixels_x = 2560
+display_pixels_y = 1440
+display_width = 120.96
+max_print_height = 150
+min_exposure_time = 1
+max_exposure_time = 120
+min_initial_exposure_time = 1
+max_initial_exposure_time = 300
+printer_correction = 1,1,1
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_PRUSA3D\nPRINTER_MODEL_SL1\n
+
+[printer:Original Prusa SL1S SPEED]
+printer_technology = SLA
+printer_model = SL1S
+printer_variant = default
+default_sla_material_profile = Prusa Orange Tough @0.05 SL1S
+default_sla_print_profile = 0.05 Normal @SL1S
+thumbnails = 400x400,800x480
+bed_shape = 0.5x0.5,127.5x0.5,127.5x80.5,0.5x80.5
+display_height = 81
+display_mirror_x = 1
+display_mirror_y = 0
+display_orientation = portrait
+display_pixels_x = 2560
+display_pixels_y = 1620
+display_width = 128
+elefant_foot_compensation = 0.2
+elefant_foot_min_width = 0.2
+fast_tilt_time = 2.5
+slow_tilt_time = 5
+gamma_correction = 1
+max_print_height = 150
+min_exposure_time = 1
+max_exposure_time = 120
+min_initial_exposure_time = 1
+max_initial_exposure_time = 300
+printer_correction = 1,1,1
+relative_correction = 1,1


### PR DESCRIPTION
As I often print pre-supported models and use PrusaSlicer on different computers, I've added print settings for pre-supported models for the SL1 and SL1S with the following changes to the normal print settings:

```
pad_enable = 0
supports_enable = 0
```